### PR TITLE
migrate from actions/attest-build-provenance to actions/attest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
           SUFFIX: ${{ needs.list.outputs.suffix }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: attest the release
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
@@ -127,7 +127,7 @@ jobs:
           SUFFIX: ${{ needs.list.outputs.suffix }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: attest the release
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
@@ -166,7 +166,7 @@ jobs:
           SUFFIX: ${{ needs.list.outputs.suffix }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: attest the release
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
@@ -206,7 +206,7 @@ jobs:
           SUFFIX: ${{ needs.list.outputs.suffix }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: attest the release
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ runner.temp }}/*.tar.zstd
 
@@ -267,7 +267,7 @@ jobs:
           SUFFIX: ${{ needs.list.outputs.suffix }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: attest the release
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ runner.temp }}/*.zip
 
@@ -329,7 +329,7 @@ jobs:
           SUFFIX: ${{ needs.list.outputs.suffix }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: attest the release
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: ${{ runner.temp }}/*.zip
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release attestation tooling across supported platform builds.
  * Release artifacts continue to be verified using the existing artifact paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->